### PR TITLE
Trim endpoint slash '/' from the base url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ on:
     branches: '**'
 
 env:
-  GO_VERSION: '1.18'
+  GO_VERSION: '1.22'
   TEST_RESULTS_DIR: /tmp/test-results
-  GOTESTSUM_VERSION: '1.8.1'
+  GOTESTSUM_VERSION: '1.10.1'
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           --jsonfile $TEST_RESULTS_DIR/json/go-test-race.log \
           --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml \
           -- ./...
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: test-results
         path: ${{ env.TEST_RESULTS_DIR }}/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul-awsauth
 
-go 1.18
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.42.34

--- a/token.go
+++ b/token.go
@@ -391,8 +391,18 @@ func (t *BearerToken) getHeader(name string) (string, error) {
 // There's a deeper explanation of this in the Vault source code.
 // https://github.com/hashicorp/vault/blob/b17e3256dde937a6248c9a2fa56206aac93d07de/builtin/credential/aws/path_login.go#L1569
 func buildHttpRequest(method, endpoint string, parsedUrl *url.URL, body string, headers http.Header) (*http.Request, error) {
-	targetUrl := fmt.Sprintf("%s%s", endpoint, parsedUrl.RequestURI())
-	request, err := http.NewRequest(method, targetUrl, strings.NewReader(body))
+	targetUrl, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	joinedPath, err := url.JoinPath(targetUrl.Path, parsedUrl.Path)
+	if err != nil {
+		return nil, err
+	}
+	targetUrl.Path = joinedPath
+	targetUrl.RawQuery = parsedUrl.RawQuery
+
+	request, err := http.NewRequest(method, targetUrl.String(), strings.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/token_test.go
+++ b/token_test.go
@@ -4,6 +4,7 @@
 package iamauth
 
 import (
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/url"
 	"testing"
@@ -484,3 +485,10 @@ var (
   "iam_request_headers":"eyJBdXRob3JpemF0aW9uIjpbIkFXUzQtSE1BQy1TSEEyNTYgQ3JlZGVudGlhbD1mYWtlLzIwMjIwMzIyL3VzLWVhc3QtMS9zdHMvYXdzNF9yZXF1ZXN0LCBTaWduZWRIZWFkZXJzPWNvbnRlbnQtbGVuZ3RoO2NvbnRlbnQtdHlwZTtob3N0O3gtYW16LWRhdGU7eC1hbXotc2VjdXJpdHktdG9rZW4sIFNpZ25hdHVyZT1lZmMzMjBiOTcyZDA3YjM4YjY1ZWIyNDI1NjgwNWUwMzE0OWRhNTg2ZDgwNGY4YzYzNjRjZTk4ZGViZTA4MGIxIl0sIkNvbnRlbnQtTGVuZ3RoIjpbIjQzIl0sIkNvbnRlbnQtVHlwZSI6WyJhcHBsaWNhdGlvbi94LXd3dy1mb3JtLXVybGVuY29kZWQ7IGNoYXJzZXQ9dXRmLTgiXSwiVXNlci1BZ2VudCI6WyJhd3Mtc2RrLWdvLzEuNDIuMzQgKGdvMS4xNy41OyBkYXJ3aW47IGFtZDY0KSJdLCJYLUFtei1EYXRlIjpbIjIwMjIwMzIyVDIxMTEwM1oiXSwiWC1BbXotU2VjdXJpdHktVG9rZW4iOlsiZmFrZSJdfQ=="
 }`
 )
+
+func TestBuildHttpRequest(t *testing.T) {
+	req, err := buildHttpRequest("POST", "https://iam.amazonaws.com/", &url.URL{}, "", http.Header{})
+	require.NoError(t, err)
+	assert.Equal(t, "POST", req.Method)
+	assert.Equal(t, "https://iam.amazonaws.com/", req.URL.String())
+}

--- a/util.go
+++ b/util.go
@@ -83,7 +83,10 @@ func GenerateLoginData(in *LoginInput) (map[string]interface{}, error) {
 		stsRequest.HTTPRequest.Header.Add(in.ServerIDHeaderName, in.ServerIDHeaderValue)
 	}
 
-	stsRequest.Sign()
+	err = stsRequest.Sign()
+	if err != nil {
+		return nil, err
+	}
 
 	// Now extract out the relevant parts of the request
 	headersJson, err := json.Marshal(stsRequest.HTTPRequest.Header)
@@ -141,6 +144,10 @@ func formatSignedEntityRequest(svc *sts.STS, in *LoginInput) (*request.Request, 
 		req.HTTPRequest.Header.Add(in.ServerIDHeaderName, in.ServerIDHeaderValue)
 	}
 
-	req.Sign()
+	err = req.Sign()
+	if err != nil {
+		return nil, err
+	}
+
 	return req, nil
 }


### PR DESCRIPTION
Updated the logic where we are removing the extra '/' from the endpoint since the resultant url was becoming 'https://iam.amazonaws.com// ' which is an invalid url when calling IAM