### PR TITLE
update golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
       with:
-        version: v1.46
+        version: v1.56.2
         args: |
           --verbose
         only-new-issues: false


### PR DESCRIPTION
Update linter version since current one is deprecated and is causing [failures in CI action](https://github.com/hashicorp/consul-awsauth/actions/runs/15991773965/job/46829056403).
