### PR TITLE
AWS sdk v2 migration : improved test coverage and context method param 

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -178,6 +178,7 @@ func TestValidateLogin(t *testing.T) {
 				Creds:               credentials.NewStaticCredentialsProvider("fake", "fake", ""),
 				IncludeIAMEntity:    c.config.EnableIAMEntityDetails,
 				STSEndpoint:         c.config.STSEndpoint,
+				IAMEndpoint:         c.config.IAMEndpoint,
 				STSRegion:           "fake-region",
 				Logger:              logger,
 				ServerIDHeaderValue: "server.id.example.com",

--- a/config_test.go
+++ b/config_test.go
@@ -124,6 +124,55 @@ func TestConfigValidate(t *testing.T) {
 				},
 			},
 		},
+		"invalid STS endpoint URL": {
+			expError: "error STSEndpoint is invalid",
+			configs: []Config{
+				{
+					BoundIAMPrincipalARNs: []string{principalArn},
+					STSEndpoint:           "://invalid-url",
+				},
+				{
+					BoundIAMPrincipalARNs: []string{principalArn},
+					STSEndpoint:           "not a url",
+				},
+			},
+		},
+		"invalid IAM endpoint URL": {
+			expError: "error IAMEndpoint is invalid",
+			configs: []Config{
+				{
+					BoundIAMPrincipalARNs: []string{principalArn},
+					IAMEndpoint:           "://invalid-url",
+				},
+				{
+					BoundIAMPrincipalARNs: []string{principalArn},
+					IAMEndpoint:           "not a url",
+				},
+			},
+		},
+		"valid STS and IAM endpoints": {
+			includeHeaderNames: true,
+			configs: []Config{
+				{
+					BoundIAMPrincipalARNs: []string{principalArn},
+					STSEndpoint:           "https://sts.amazonaws.com",
+				},
+				{
+					BoundIAMPrincipalARNs: []string{principalArn},
+					IAMEndpoint:           "https://iam.amazonaws.com",
+				},
+				{
+					BoundIAMPrincipalARNs: []string{principalArn},
+					STSEndpoint:           "https://sts.us-west-2.amazonaws.com",
+					IAMEndpoint:           "https://iam.amazonaws.com",
+				},
+				{
+					BoundIAMPrincipalARNs: []string{principalArn},
+					STSEndpoint:           "http://localhost:4566/sts",
+					IAMEndpoint:           "http://localhost:4566/iam",
+				},
+			},
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
This is in continuation with the PR - https://github.com/hashicorp/consul-awsauth/pull/17 

**Changes:**

- Addressed the below mentioned review point wrt util.go :
   - Usage context as input parameter in GenerateLogin - **DIDN'T Do**  ( As it is a code migration and GenerateLoginData() fucntion argumnents and return type is kept same as earlier. This function gets called up in consul CE & ENT there will be unnecessary changes required there too)
   - Use context as an input parameter in other util.go functions  - **DONE** ( As it was an internal call from GenarateLoginData() )
- Validate the input parameter of GenerateLoginData() in util.go before processing the input - **DONE**
   
- Improved Test coverage in the repository - **DONE**
- Provided custom IAM Endpoint usage scope

Slack thread for review points of earlier PR - https://ibm-cloud.slack.com/archives/C096VV4GZDM/p1770092141615239
 